### PR TITLE
Add server-side logic to skip validation for hidden fields

### DIFF
--- a/contact-form-7-conditional-fields.php
+++ b/contact-form-7-conditional-fields.php
@@ -4,7 +4,7 @@ Plugin Name: Contact Form 7 Conditional Fields
 Plugin URI: http://bdwm.be/
 Description: Adds support for conditional fields to Contact Form 7. This plugin depends on Contact Form 7.
 Author: Jules Colle
-Version: 0.1.6
+Version: 0.1.8
 Author URI: http://bdwm.be/
 */
 
@@ -22,7 +22,7 @@ Author URI: http://bdwm.be/
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
-*/
+ */
 ?>
 <?php
 
@@ -46,6 +46,9 @@ function wpcf7cf_plugin_url( $path = '' ) {
 }
 
 class ContactForm7ConditionalFields {
+	private $hidden_fields = array();
+	private $visible_groups = array();
+	private $hidden_groups = array();
 
 	function __construct() {
 
@@ -58,6 +61,9 @@ class ContactForm7ConditionalFields {
 		// Tag generator
 		add_action('load-contact_page_wpcf7-new', array(__CLASS__, 'tag_generator'));
 		add_action('load-toplevel_page_wpcf7', array(__CLASS__, 'tag_generator'));
+
+		add_filter( 'wpcf7_posted_data', array($this, 'remove_hidden_post_data') );
+		add_filter( 'wpcf7_mail_components', array($this, 'hide_hidden_mail_fields') );
 
 		register_activation_hook(__FILE__, array($this, 'activate'));
 
@@ -143,6 +149,196 @@ class ContactForm7ConditionalFields {
 		</div>
 		<?php
 	}
+
+	/**
+	 * Remove validation requirements for fields that are hidden at the time of form submission.
+	 * Called using add_filter( 'wpcf7_validate_[tag_type]', array($this, 'skip_validation_for_hidden_fields'), 2, 2 );
+	 * where the priority of 2 causes this to kill any validations with a priority higher than 2
+	 *
+	 * @param $result
+	 * @param $tag
+	 *
+	 * @return mixed
+	 */
+	function skip_validation_for_hidden_fields($result, $tag) {
+		global $wp_filter;
+		$hidden_fields = $this->get_hidden_fields();
+
+		// If this field is hidden, skip the rest of the validation hooks
+		if( in_array($tag['name'], $hidden_fields) ) {
+			// end() skips to the end of the $wp_filter array, effectively skipping any filters with a priority
+			// lower than whatever priority this function was given.
+			// In our case, this means that a hidden field won't be marked as "Invalid", regardless of its contents
+			// unless it's done by a filter of priority 1 or 2
+			end( $wp_filter[ current_filter() ] );
+		}
+
+		return $result;
+	}
+
+
+	/**
+	 * When a CF7 form is posted, check the form for hidden fields, then remove those fields from the post data
+	 *
+	 * @param $posted_data
+	 *
+	 * @return mixed
+	 */
+	function remove_hidden_post_data($posted_data) {
+		$hidden_fields = $this->get_hidden_fields($posted_data);
+
+		foreach( $hidden_fields as $name => $value ) {
+			unset( $posted_data[$name] );
+		}
+		return $posted_data;
+	}
+
+
+	/**
+	 * Finds the currently submitted form and returns an array of fields that are hidden and should be ignored
+	 *
+	 * @param bool|array $posted_data
+	 * @return mixed
+	 */
+	function get_hidden_fields($posted_data = false) {
+		if ( isset( $posted_data['_wpcf7'] ) ) {
+			// When called by wpcf7cf_remove_hidden_post_data() and $posted_data is available
+			$form_id = $posted_data['_wpcf7'];
+		} else {
+			// When called from skip_validation_for_hidden_fields(), use WPCF7_Submission object to get form id
+			$form_id = WPCF7_Submission::get_instance()->get_posted_data( '_wpcf7' );
+		}
+
+		// We only need to run through this once, so check to see if the global variable exists.
+		if ( 0 == count( $this->hidden_fields ) ) {
+			// Get the WPCF7_ContactForm object for this form
+			$contact_form = WPCF7_ContactForm::get_instance( $form_id );
+
+			// While we have the contact form object, find all used tags so we can add our validation filter
+			foreach( (array) $contact_form->form_scan_shortcode() as $tag ) {
+				//Priority of 2 allows other filters at priority 1 or 2 to actually validate hidden fields (just in case)
+				add_filter( 'wpcf7_validate_' . $tag['type'], array($this, 'skip_validation_for_hidden_fields'), 2, 2 );
+			}
+
+			// Get the form properties so we have access to the form itself
+			$form_properties = $contact_form->get_properties();
+
+			//Find out which tags are in which groups
+			$dom = new DOMDocument();
+			$dom->loadHTML($form_properties['form']);
+			$divs = $dom->getElementsByTagName('div');
+			$groups = array();
+			foreach ($divs as $div) {
+				$is_group = false;
+				$id = 0;
+				foreach($div->attributes as $attribute) {
+					if ( 'data-class' == $attribute->name && 'wpcf7cf_group' == $attribute->value ) {
+						// Group divs will have a data-class of wpcf7cf_group
+						$is_group = true;
+					}
+					if ( 'id' == $attribute->name ) {
+						$id = $attribute->value;
+					}
+				}
+				if ( $is_group  ) {
+					// Match all tag names (format = [tag_type tag_name] or [tag_type tag_name options values etc...])
+					preg_match_all("/\[[^\s\]]* ([^\s\]]*)[^\]]*\]/", $div->textContent, $matches);
+					foreach( $matches[1] as $tag ) {
+						$groups[$id][] = $tag;
+					}
+				}
+			}
+			// $groups is now an array of groups (by id) with an array of the name of each tag that is inside that group.
+
+
+			$visible_groups = $this->get_visible_groups($posted_data);
+
+			// Iterate through the groups.
+			// When we find one that's not in the $visible_groups array, add its tags to our list of hidden tags
+			foreach( $groups as $group => $fields ) {
+				if ( ! in_array($group, $visible_groups) ) {
+					$this->hidden_groups[] = $group;
+					$this->hidden_fields = array_merge($this->hidden_fields, $fields);
+				}
+			}
+
+
+		}
+		return $this->hidden_fields;
+	}
+
+	function get_visible_groups($posted_data) {
+		// Groups are hidden by default. Find all the visible ones and mark them.
+		// This is a duplicate of the logic in js/scripts.js and needs to be included
+		// so our verification is done server-side. If we ran this verification in
+		// javascript, then all the form's normal validation could be overridden.
+		//
+		// Unfortunately, separate javascript and php validation is probably necessary since to use only php
+		// would mean that every onChange() would require an ajax call, and that'd get too slow.
+		$form_id = $posted_data['_wpcf7'];
+		if( $this->visible_groups ) {
+			return $this->visible_groups;
+		}
+		$this->visible_groups = array();
+		$conditions = get_post_meta($form_id,'wpcf7cf_options', true);
+		foreach( $conditions as $condition ) {
+			if ( $condition['then_visibility'] == 'show' ) {
+				if ( is_array($posted_data[ $condition['if_field'] ]) ) {
+					if ( 'not equals' == $condition['operator'] && ! in_array( $condition['if_value'], $posted_data[ $condition['if_field'] ] ) ) {
+						$this->visible_groups[] = $condition['then_field'];
+					} elseif ( 'equals' == $condition['operator'] && in_array( $condition['if_value'], $posted_data[ $condition['if_field'] ] ) ) {
+						$this->visible_groups[] = $condition['then_field'];
+					}
+				} else {
+					if ( 'not equals' == $condition['operator'] && $condition['if_value'] != $posted_data[ $condition['if_field'] ] ) {
+						$this->visible_groups[] = $condition['then_field'];
+					} elseif ( 'equals' == $condition['operator'] && $condition['if_value'] == $posted_data[ $condition['if_field'] ] ) {
+						$this->visible_groups[] = $condition['then_field'];
+					}
+				}
+			}
+		}
+		return $this->visible_groups;
+	}
+
+	function hide_hidden_mail_fields( $components ) {
+		$regex = '@\[[\t ]*([a-zA-Z_][0-9a-zA-Z:._-]*)[\t ]*\](.*?)\[[\t ]*/[\t ]*\1[\t ]*\]@s';
+		// [1] = name [2] = contents
+
+		$components['body'] = preg_replace_callback(
+			$regex,
+			function ( $matches ) {
+				$name = $matches[1];
+				$content = $matches[2];
+				stevish_log("hidden_groups: " . print_r($this->hidden_groups, true) . "visible_groups: " . print_r($this->visible_groups, true) );
+				if ( in_array( $name, $this->hidden_groups ) ) {
+					// The tag name represents a hidden group, so replace everything from [tagname] to [/tagname] with nothing
+					return '';
+				} elseif ( in_array( $name, $this->visible_groups ) ) {
+					// The tag name represents a visible group, so remove the tags themselves, but return everything else
+					return $content;
+				} else {
+					// The tag name doesn't represent a group that was used in the form. Leave it alone (return the entire match).
+					return $matches[0];
+				}
+			},
+			$components['body'] );
+		return $components;
+	}
+	function hide_hidden_mail_fields_callback( $matches ) {
+		$name = $matches[1];
+		$content = $matches[2];
+		if ( in_array( $name, $this->hidden_groups ) ) {
+			// The tag name represents a hidden group, so replace everything from [tagname] to [/tagname] with nothing
+			return '';
+		} elseif ( in_array( $name, $this->visible_groups ) ) {
+			// The tag name represents a visible group, so remove the tags themselves, but return everything else
+			return $content;
+		} else {
+			// The tag name doesn't represent a group that was used in the form. Leave it alone (return the entire match).
+			return $matches[0];
+		}
+	}
 }
 
 new ContactForm7ConditionalFields;
@@ -156,7 +352,7 @@ function wpcf7cf_properties($properties, $wpcf7form) {
 		$find = array(
 			'/\[group\s*\]/s', // matches [group    ] or [group]
 			'/\[group\s+([^\s\]]*)\s*([^\]]*)\]/s', // matches [group something some:thing] or [group   something  som   ]
-			                                        // doesn't match [group-special something]
+			// doesn't match [group-special something]
 			'/\[\/group\]/s'
 		);
 
@@ -176,7 +372,7 @@ function wpcf7cf_properties($properties, $wpcf7form) {
 $global_count = 0;
 
 add_action('wpcf7_contact_form', 'wpcf7cf_enqueue_scripts', 10, 1);
-function wpcf7cf_enqueue_scripts($cf7form) {
+function wpcf7cf_enqueue_scripts(WPCF7_ContactForm $cf7form) {
 
 	if (is_admin()) return;
 


### PR DESCRIPTION
Alright, this one handles emails too. The way you filer an email is use the name of the tag (just like you do to display the result of a tag), along with a closing tag of the same thing:

    [name-block]
    First Name: [firstname]
    Last Name: [lastname]
    [/nameblock]
    Other stuff...

Assuming you had `[group name-block]...[/group]` tags in the form, if the group is visible when they submit the form, then it will show the two name lines (but not the tags). If the group is hidden, it won't show the contents or the tags. If there are no groups matching that id, then the plugin will leave it alone.