### PR TITLE
remove hidden fields from posted data

### DIFF
--- a/cf7cf.php
+++ b/cf7cf.php
@@ -137,7 +137,7 @@ class ContactForm7ConditionalFields {
         $this->set_hidden_fields_arrays($posted_data);
 
         foreach( $this->hidden_fields as $name => $value ) {
-            unset( $posted_data[$name] );
+            unset( $posted_data[$value] );
         }
 
         return $posted_data;


### PR DESCRIPTION
Hello Jules Colle

greetings from south India.  I found an issue with the CF plugin which I [raised in the WP forum](https://wordpress.org/support/topic/possible-bug-hidden-fields-not-removed-from-cf7-posted-data/).

I am developing the pluing [CF7 Smart-grid layout extension](https://wordpress.org/plugins/cf7-grid-layout/) and there is an issue with the validation of hidden (required) fields. The method,

   ```
function remove_hidden_post_data($posted_data) {
        $this->set_hidden_fields_arrays($posted_data);
        foreach( $this->hidden_fields as $name => $value ) {
            unset( $posted_data[$name] );
        }
        return $posted_data;
    }
```

in the class ContactForm7ConditionalFields (file cf7cf.php) is removing the hidden fields from the cf7 posted data, however, I believe you should be using the $value variable which holds the field name rather than the $name variable which is simply the index of your $this->hidden_fields array.

Removing the hidden (unused) fields allows me to skip over the unused fields as I am hooking the wpcf7_validate to validate more complex field inputs which cf7 is unable to handle properly.

Correct me if I am wrong, but I think this is bug, cause otherwise I don’t see the purpose of the method.

thanks