### PR TITLE
Make plugin translatable (i18n)

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -17,7 +17,7 @@ add_filter('wpcf7_editor_panels', 'add_conditional_panel');
 function add_conditional_panel($panels) {
 	if ( current_user_can( 'wpcf7_edit_contact_form' ) ) {
 		$panels['wpcf7cf-conditional-panel'] = array(
-			'title'    => __( 'Conditional fields', 'wpcf7cf' ),
+			'title'    => __( 'Conditional fields', 'cf7-conditional-fields' ),
 			'callback' => 'wpcf7cf_editor_panel_conditional'
 		);
 	}
@@ -27,7 +27,7 @@ function add_conditional_panel($panels) {
 function wpcf7cf_all_field_options($post, $selected = '-1') {
 	$all_fields = $post->scan_form_tags();
 	?>
-	<option value="-1" <?php echo $selected == '-1'?'selected':'' ?>>-- Select field --</option>
+	<option value="-1" <?php echo $selected == '-1'?'selected':'' ?>><?php _e( '-- Select field --', 'cf7-conditional-fields' ); ?></option>
 	<?php
 	foreach ($all_fields as $tag) {
 		if ($tag['type'] == 'group' || $tag['name'] == '') continue;
@@ -41,7 +41,7 @@ function wpcf7cf_all_group_options($post, $selected = '-1') {
 	$all_groups = $post->scan_form_tags(array('type'=>'group'));
 
 	?>
-	<option value="-1" <?php echo $selected == '-1'?'selected':'' ?>>-- Select group --</option>
+	<option value="-1" <?php echo $selected == '-1'?'selected':'' ?>><?php _e( '-- Select group --', 'cf7-conditional-fields' ); ?></option>
 	<?php
 	foreach ($all_groups as $tag) {
 		?>
@@ -80,8 +80,8 @@ function wpcf7cf_editor_panel_conditional($form) {
 	if ($form_id === false) {
 		?>
 		    <div class="wpcf7cf-inner-container">
-				<h2><?php echo esc_html( __( 'Conditional fields', 'wpcf7cf' ) ); ?></h2>
-				<p>You need to save your form, before you can start adding conditions.</p>
+				<h2><?php _e( 'Conditional fields', 'cf7-conditional-fields' ); ?></h2>
+				<p><?php _e( 'You need to save your form, before you can start adding conditions.', 'cf7-conditional-fields' ); ?></p>
 			</div>
 		<?php
 		return;
@@ -97,14 +97,14 @@ function wpcf7cf_editor_panel_conditional($form) {
     <div class="wpcf7cf-inner-container">
 
 		<label class="wpcf7cf-switch" id="wpcf7cf-text-only-switch">
-			<span class="label">Text mode</span>
+			<span class="label"><?php _e( 'Text mode', 'cf7-conditional-fields' ); ?></span>
 			<span class="switch">
 				<input type="checkbox" id="wpcf7cf-text-only-checkbox" name="wpcf7cf-text-only-checkbox" value="text_only" <?php echo $is_text_only ? 'checked':''; ?>>
 				<span class="slider round"></span>
 			</span>
 		</label>
 
-		<h2><?php echo esc_html( __( 'Conditional fields', 'wpcf7cf' ) ); ?></h2>
+		<h2><?php _e( 'Conditional fields', 'cf7-conditional-fields' ); ?></h2>
 
 		<div id="wpcf7cf-entries-ui" style="display:none">
 			<?php
@@ -116,13 +116,16 @@ function wpcf7cf_editor_panel_conditional($form) {
 				?>
 			</div>
 			
-			<span id="wpcf7cf-add-button" title="add new rule">+ add new conditional rule</span>
+			<span id="wpcf7cf-add-button" title="<?php _e( 'add new rule', 'cf7-conditional-fields' ); ?>"><?php _e( '+ add new conditional rule', 'cf7-conditional-fields'); ?></span>
 
 			<div id="wpcf7cf-a-lot-of-conditions" class="wpcf7cf-notice notice-warning" style="display:none;">
 				<p>
-					<strong>Wow, That's a lot of conditions!</strong><br>
-					You can only add up to <?php echo WPCF7CF_MAX_RECOMMENDED_CONDITIONS ?> conditions using this interface.
-					Please switch to <strong>Text mode</strong> if you want to add more than <?php echo WPCF7CF_MAX_RECOMMENDED_CONDITIONS ?> conditions.
+					<strong><?php _e( 'Wow, That\'s a lot of conditions!', 'cf7-conditional-fields' ); ?></strong><br>
+					<?php 
+					// translators: 1. max recommended conditions
+					echo sprintf( __( 'You can only add up to %d conditions using this interface.', 'cf7-conditional-fields' ), WPCF7CF_MAX_RECOMMENDED_CONDITIONS ) . ' ';
+					// translators: 1,2: strong tags, 3. max recommended conditions
+					printf( __( 'Please switch to %1$sText mode%2$s if you want to add more than %3$d conditions.', 'cf7-conditional-fields' ), '<strong>', '</strong>', WPCF7CF_MAX_RECOMMENDED_CONDITIONS ); ?>
 				</p>
 			</div>
 
@@ -248,7 +251,7 @@ function print_entries_html($form, $wpcf7cf_entries = false) {
         }
 		?>
             <div class="wpcf7cf-if">
-                <span class="label">Show</span>
+                <span class="label"><?php _e( 'Show', 'cf7-conditional-fields' ); ?></span>
                 <select class="then-field-select"><?php wpcf7cf_all_group_options($form, $entry['then_field']); ?></select>
             </div>
             <div class="wpcf7cf-and-rules" data-next-index="<?php echo count($and_entries) ?>">
@@ -259,13 +262,12 @@ function print_entries_html($form, $wpcf7cf_entries = false) {
 				foreach($and_entries as $and_i => $and_entry) {
 					?>
                     <div class="wpcf7cf-and-rule">
-                        <span class="rule-part if-txt label">if</span>
+                        <span class="rule-part if-txt label"><?php _e( 'if', 'cf7-conditional-fields' ); ?></span>
                         <select class="rule-part if-field-select"><?php wpcf7cf_all_field_options( $form, $and_entry['if_field'] ); ?></select>
                         <select class="rule-part operator"><?php all_operator_options( $and_entry['operator'] ) ?></select>
-                        <input class="rule-part if-value" type="text"
-                               placeholder="value" value="<?php echo $and_entry['if_value'] ?>">
-                        <span class="and-button">And</span>
-                        <span title="delete rule" class="rule-part delete-button">remove</span>
+                        <input class="rule-part if-value" type="text" placeholder="<?php _e( 'value', 'cf7-conditional-fields' ); ?>" value="<?php echo $and_entry['if_value'] ?>">
+                        <span class="and-button"><?php _e( 'And', 'cf7-conditional-fields' ); ?></span>
+                        <span title="<?php _e( 'delete rule', 'cf7-conditional-fields' ); ?>" class="rule-part delete-button"><?php _e( 'remove', 'cf7-conditional-fields' ); ?></span>
                     </div>
 					<?php
 				}

--- a/cf7cf.php
+++ b/cf7cf.php
@@ -125,7 +125,7 @@ class CF7CF {
             return;
 
         wpcf7_add_tag_generator('group',
-            __('Conditional Fields Group', 'wpcf7cf'),
+            __('Conditional Fields Group', 'cf7-conditional-fields'),
             'wpcf7-tg-pane-group',
             array(__CLASS__, 'tg_pane')
         );
@@ -137,7 +137,7 @@ class CF7CF {
         $args = wp_parse_args( $args, array() );
         $type = 'group';
 
-        $description = __( "Generate a group tag to group form elements that can be shown conditionally.", 'cf7cf' );
+        $description = __( "Generate a group tag to group form elements that can be shown conditionally.", 'cf7-conditional-fields' );
 
         include 'tg_pane_group.php';
     }

--- a/contact-form-7-conditional-fields.php
+++ b/contact-form-7-conditional-fields.php
@@ -1,12 +1,15 @@
 <?php
 /**
-Plugin Name: Contact Form 7 Conditional Fields
-Plugin URI: http://bdwm.be/
-Description: Adds support for conditional fields to Contact Form 7. This plugin depends on Contact Form 7.
-Author: Jules Colle
-Version: 1.9.14
-Author URI: http://bdwm.be/
- */
+* Plugin Name: Contact Form 7 Conditional Fields
+* Plugin URI: http://bdwm.be/
+* Description: Adds support for conditional fields to Contact Form 7. This plugin depends on Contact Form 7.
+* Author: Jules Colle
+* Version: 1.9.14
+* Author URI: http://bdwm.be/
+* Text Domain: cf7-conditional-fields
+* License: GPL v2 or later
+* License URI: https://www.gnu.org/licenses/gpl-2.0.html
+*/
 
 /**
  * This program is free software; you can redistribute it and/or modify
@@ -32,7 +35,10 @@ if ( function_exists( 'wpcf7cf_pro_deactivate_free_version_notice' ) ) {
 	function wpcf7cf_pro_deactivate_free_version_notice() {
 		?>
         <div class="notice notice-error is-dismissible">
-            <p><?php echo sprintf( __( '<strong>Contact Form 7 - Conditional Fields PRO</strong> needs to %sdeactivate the free plugin%s', 'wpcf7cf' ), '<a href="' . wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=cf7-conditional-fields%2Fcontact-form-7-conditional-fields.php&amp;plugin_status=all&amp;paged=1&amp;s=', 'deactivate-plugin_cf7-conditional-fields/contact-form-7-conditional-fields.php' ) . '">', '</a>' ); ?></p>
+						<p><?php 
+						// translators: 1. <a>, 2. </a> 
+						printf( __( '<strong>Contact Form 7 - Conditional Fields PRO</strong> needs to %1$sdeactivate the free plugin%1$s', 'cf7-conditional-fields' ), '<a href="' . wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=cf7-conditional-fields%2Fcontact-form-7-conditional-fields.php&amp;plugin_status=all&amp;paged=1&amp;s=', 'deactivate-plugin_cf7-conditional-fields/contact-form-7-conditional-fields.php' ) . '">', '</a>' ); 
+						?></p>
         </div>
 		<?php
 	}

--- a/tg_pane_group.php
+++ b/tg_pane_group.php
@@ -6,17 +6,17 @@
             <tbody>
 
             <tr>
-                <th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-name' ); ?>"><?php echo esc_html( __( 'Name', 'contact-form-7' ) ); ?></label></th>
+                <th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-name' ); ?>"><?php _e( 'Name', 'cf7-conditional-fields' ); ?></label></th>
                 <td><input type="text" name="name" class="tg-name oneline" id="<?php echo esc_attr( $args['content'] . '-name' ); ?>" /></td>
             </tr>
 
             <tr>
-                <th scope="row"><label for="clear_on_hide"><?php echo esc_html( __( 'Clear on hide', 'contact-form-7' ) ); ?></label></th>
+                <th scope="row"><label for="clear_on_hide"><?php _e( 'Clear on hide', 'cf7-conditional-fields' ); ?></label></th>
                 <td><input type="checkbox" name="clear_on_hide" class="option" id="clear_on_hide" /></td>
             </tr>
 
             <tr>
-                <th scope="row"><label for="inline"><?php echo esc_html( __( 'Inline', 'contact-form-7' ) ); ?></label></th>
+                <th scope="row"><label for="inline"><?php _e( 'Inline', 'cf7-conditional-fields' ); ?></label></th>
                 <td><input type="checkbox" name="inline" class="option" id="inline" /></td>
             </tr>
 
@@ -29,7 +29,7 @@
     <input type="text" name="<?php echo $type; ?>" class="tag code" readonly="readonly" onfocus="this.select()" />
 
     <div class="submitbox">
-        <input type="button" class="button button-primary insert-tag" value="<?php echo esc_attr( __( 'Insert Tag', 'contact-form-7' ) ); ?>" />
+        <input type="button" class="button button-primary insert-tag" value="<?php _e( 'Insert Tag', 'cf7-conditional-fields' ); ?>" />
     </div>
 
     <br class="clear" />

--- a/wpcf7cf-options.php
+++ b/wpcf7cf-options.php
@@ -70,31 +70,31 @@ function wpcf7cf_load_page_options_wp_admin_style() {
 
 add_action('admin_menu', 'wpcf7cf_admin_add_page');
 function wpcf7cf_admin_add_page() {
-    add_submenu_page('wpcf7', 'Conditional Fields', 'Conditional Fields', WPCF7_ADMIN_READ_WRITE_CAPABILITY, 'wpcf7cf', 'wpcf7cf_options_page' );
+    add_submenu_page('wpcf7', __( 'Conditional Fields', 'cf7-conditional-fields' ), __( 'Conditional Fields', 'cf7-conditional-fields' ), WPCF7_ADMIN_READ_WRITE_CAPABILITY, 'wpcf7cf', 'wpcf7cf_options_page' );
 }
 
 function wpcf7cf_options_page() {
     $settings = wpcf7cf_get_settings();
 
     if (isset($_POST['reset'])) {
-        echo '<div id="message" class="updated fade"><p><strong>Settings restored to defaults</strong></p></div>';
+        echo '<div id="message" class="updated fade"><p><strong>' . __( 'Settings restored to defaults', 'cf7-conditional-fields' ) . '</strong></p></div>';
     } else if (isset($_REQUEST['settings-updated'])) {
-        echo '<div id="message" class="updated fade"><p><strong>Settings updated</strong></p></div>';
+        echo '<div id="message" class="updated fade"><p><strong>' . __( 'Settings updated', 'cf7-conditional-fields' ) . '</strong></p></div>';
     }
 
     ?>
 
     <div class="wrap wpcf7cf-admin-wrap">
-        <h2>Contact Form 7 - Conditional Fields Settings</h2>
+        <h2><?php _e( 'Contact Form 7 - Conditional Fields Settings', 'cf7-conditional-fields'); ?></h2>
         <?php if (!$settings['notice_dismissed']) { ?>
-        <div class="wpcf7cf-options-notice notice notice-warning is-dismissible"><div style="padding: 10px 0;"><strong>Notice</strong>: These are global settings for Contact Form 7 - Conditional Fields. <br><br><strong>How to create/edit conditional fields?</strong>
+        <div class="wpcf7cf-options-notice notice notice-warning is-dismissible"><div style="padding: 10px 0;"><?php _e( '<strong>Notice</strong>: These are global settings for Contact Form 7 - Conditional Fields.', 'cf7-conditional-fields'); ?> <br><br><strong><?php _e( 'How to create/edit conditional fields?', 'cf7-conditional-fields'); ?></strong>
             <ol>
-                <li>Create a new Contact Form or edit an existing one</li>
-                <li>Create at least one [group] inside the form</li>
-                <li>Save the Contact Form</li>
-                <li>go to the <strong><em>Conditional Fields</em></strong> Tab</li>
+                <li><?php _e( 'Create a new Contact Form or edit an existing one', 'cf7-conditional-fields'); ?></li>
+                <li><?php _e( 'Create at least one [group] inside the form', 'cf7-conditional-fields'); ?></li>
+                <li><?php _e( 'Save the Contact Form', 'cf7-conditional-fields'); ?></li>
+                <li><?php _e( 'Go to the <strong><em>Conditional Fields</em></strong> Tab', 'cf7-conditional-fields'); ?></li>
             </ol>
-                <a href="https://conditional-fields-cf7.bdwm.be/conditional-fields-for-contact-form-7-tutorial/" target="_blank">Show me an example</a> | <a class="notice-dismiss-2" href="#">Dismiss notice</a>
+                <a href="https://conditional-fields-cf7.bdwm.be/conditional-fields-for-contact-form-7-tutorial/" target="_blank"><?php _e( 'Show me an example', 'cf7-conditional-fields'); ?></a> | <a class="notice-dismiss-2" href="#"><?php _e( 'Dismiss notice', 'cf7-conditional-fields'); ?></a>
         </div></div>
         <?php } ?>
         <form action="options.php" method="post">
@@ -104,23 +104,23 @@ function wpcf7cf_options_page() {
 
             <?php
 
-            echo '<h3>Default animation Settings</h3>';
+            echo '<h3>' . __( 'Default animation Settings', 'cf7-conditional-fields') . '</h3>';
             wpcf7cf_input_fields_wrapper_start();
 
             wpcf7cf_input_select('animation', array(
-                'label' => 'Animation',
-                'description' => 'Use animations while showing/hiding groups',
-                'select_options' => array('yes' => 'Enabled', 'no'=> 'Disabled')
+                'label' => __( 'Animation', 'cf7-conditional-fields'),
+                'description' => __( 'Use animations while showing/hiding groups', 'cf7-conditional-fields'),
+                'select_options' => array('yes' => __( 'Enabled', 'cf7-conditional-fields'), 'no'=> __( 'Disabled', 'cf7-conditional-fields'))
             ));
 
             wpcf7cf_input_field('animation_intime', array(
-                'label' => 'Animation In time',
-                'description' => 'A positive integer value indicating the time, in milliseconds, it will take for each group to show.',
+                'label' => __( 'Animation In time', 'cf7-conditional-fields'),
+                'description' => __( 'A positive integer value indicating the time, in milliseconds, it will take for each group to show.', 'cf7-conditional-fields'),
             ));
 
             wpcf7cf_input_field('animation_outtime', array(
-                'label' => 'Animation Out Time',
-                'description' => 'A positive integer value indicating the time, in milliseconds, it will take for each group to hide.',
+                'label' => __( 'Animation Out Time', 'cf7-conditional-fields'),
+                'description' => __( 'A positive integer value indicating the time, in milliseconds, it will take for each group to hide.', 'cf7-conditional-fields'),
             ));
 
             wpcf7cf_input_fields_wrapper_end();
@@ -128,28 +128,30 @@ function wpcf7cf_options_page() {
 
             if (!WPCF7CF_IS_PRO) {
             ?>
-            <h3>Conditional Fields PRO</h3>
-            Get conditional Fields PRO to unlock the full potential of CF7
+            <h3><?php _e( 'Conditional Fields PRO', 'cf7-conditional-fields'); ?></h3>
+            <?php _e( 'Get Conditional Fields PRO to unlock the full potential of CF7', 'cf7-conditional-fields'); ?>
             <ul class="wpcf7cf-list">
-                <li>Repeaters</li>
-                <li>Regular expressions</li>
-                <li>Togglebuttons</li>
-                <li>Additional operators <code>&lt;</code> <code>&gt;</code> <code>&le;</code> <code>&ge;</code> <code>is empty</code></li>
-                <li>Multistep (with Summary)</li>
-                <li>More comming soon (Calculated Fields, ...)</li>
+                <li><?php _e( 'Repeaters', 'cf7-conditional-fields'); ?></li>
+                <li><?php _e( 'Regular expressions', 'cf7-conditional-fields'); ?></li>
+                <li><?php _e( 'Toggle buttons', 'cf7-conditional-fields'); ?></li>
+                <li><?php _e( 'Additional operators', 'cf7-conditional-fields'); ?>< <code>&lt;</code> <code>&gt;</code> <code>&le;</code> <code>&ge;</code> <code><?php _e( 'is empty', 'cf7-conditional-fields'); ?></code></li>
+                <li><?php _e( 'Multistep (with Summary)', 'cf7-conditional-fields'); ?></li>
+                <li><?php _e( 'More comming soon (Calculated Fields, ...)', 'cf7-conditional-fields'); ?></li>
             </ul>
-            <p><a target="_blank" class="button button-primary" href="https://conditional-fields-cf7.bdwm.be/contact-form-7-conditional-fields-pro/">Get PRO</a></p>
+            <p><a target="_blank" class="button button-primary" href="https://conditional-fields-cf7.bdwm.be/contact-form-7-conditional-fields-pro/"><?php _e( 'Get PRO', 'cf7-conditional-fields'); ?></a></p>
             <?php
             }
             do_action('wpcf7cf_after_animation_settings');
 
-            echo '<h3>Advanced Settings</h3>';
+            echo '<h3>' . __( 'Advanced Settings', 'cf7-conditional-fields') . '</h3>';
             wpcf7cf_input_fields_wrapper_start();
 
             wpcf7cf_input_select('conditions_ui', array(
-                'label' => 'Conditonal Fields UI',
-                'description' => 'If you want to add more than '.WPCF7CF_MAX_RECOMMENDED_CONDITIONS.' conditions, it\'s recommended to switch to <strong>Text mode</strong> mode for better performance.',
-                'select_options' => array('normal'=> 'Normal', 'text_only' => 'Text mode')
+                'label' => __( 'Conditional Fields UI', 'cf7-conditional-fields'),
+                'description' => sprintf( 
+                    // translators: max recommended conditions
+                    __( 'If you want to add more than %s conditions, it\'s recommended to switch to <strong>Text mode</strong> mode for better performance.', 'cf7-conditional-fields' ), WPCF7CF_MAX_RECOMMENDED_CONDITIONS ),
+                'select_options' => array('normal'=> __( 'Normal', 'cf7-conditional-fields'), 'text_only' => __( 'Text mode', 'cf7-conditional-fields'))
             ));
             
             wpcf7cf_input_fields_wrapper_end();
@@ -160,17 +162,17 @@ function wpcf7cf_options_page() {
 
         </form></div>
 
-    <h3>Restore Default Settings</h3>
+    <h3><?php _e( 'Restore Default Settings', 'cf7-conditional-fields' ); ?></h3>
     <form method="post" id="reset-form" action="">
         <p class="submit">
-            <input name="reset" class="button button-secondary" type="submit" value="Restore defaults" >
+            <input name="reset" class="button button-secondary" type="submit" value="<?php _e( 'Restore defaults', 'cf7-conditional-fields' ); ?>" >
             <input type="hidden" name="action" value="reset" />
         </p>
     </form>
     <script>
         (function($){
             $('#reset-form').submit(function() {
-                return confirm('Are you sure you want to reset the plugin settings to the default values? All changes you have previously made will be lost.');
+                return confirm( __( 'Are you sure you want to reset the plugin settings to the default values? All changes you have previously made will be lost.', 'cf7-conditional-fields' ) );
             });
         }(jQuery))
     </script>
@@ -220,7 +222,7 @@ function wpcf7cf_input_field($slug, $args) {
         <td>
             <input type="text" data-default-value="<?php echo $default ?>" value="<?php echo $settings[$slug] ?>" id="<?php echo WPCF7CF_OPTIONS.'_'.$slug ?>" name="<?php echo WPCF7CF_OPTIONS.'['.$slug.']' ?>">
             <p class="description" id="<?php echo WPCF7CF_OPTIONS.'_'.$slug ?>-description">
-                <?php echo $description ?><?php if (!empty($default)) echo ' (Default: '.$default.')' ?>
+                <?php echo $description ?><?php if (!empty($default)) echo ' (' . __( 'Default:', 'cf7-conditional-fields' ) . ' '.$default.')' ?>
             </p>
         </td>
     </tr>
@@ -258,7 +260,7 @@ function wpcf7cf_input_select($slug, $args) {
                     <?php } ?>
                 </select>
                 <p class="description" id="<?php echo WPCF7CF_OPTIONS.'_'.$slug ?>-description">
-                    <?php echo $description ?><?php if (!empty($default)) echo ' (Default: '.$select_options[$default].')' ?>
+                    <?php echo $description ?><?php if (!empty($default)) echo ' (' . __( 'Default:', 'cf7-conditional-fields' ) . ' '.$select_options[$default].')' ?>
                 </p>
             </td>
         </tr>


### PR DESCRIPTION
- Add text domain to plugin header comments.
- Change text domain parameter from `wpcf7cf` to `cf7-conditional-fields` in current translatable strings.
- Make raw strings translatable.

(Issued: #18)