### PR TITLE
fix missing admin UI in Smart Grid Editor

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -9,12 +9,17 @@ function wpcf7cf_admin_enqueue_scripts( $hook_suffix ) {
 
 	if ( isset($_GET['page']) && ( $_GET['page'] == 'wpcf7' && isset($_GET['post']) || $_GET['page'] == 'wpcf7-new' ) ) {
 		 //only load styles and scripts if this is a CF7 detail page.
-
-		wp_enqueue_script('cf7cf-scripts-admin', wpcf7cf_plugin_url( 'js/scripts_admin.js' ),array('jquery-ui-autocomplete', 'jquery-ui-sortable'), WPCF7CF_VERSION,true);
-		wp_localize_script('cf7cf-scripts-admin', 'wpcf7cf_options_0', wpcf7cf_get_settings());
-		//wp_localize_script('cf7cf-scripts-admin', 'wpcf7cf_newEntryHTML', );
+		wpcf7cf_admin_enqueue_form_edit_scripts($hook_suffix);
 	}
 
+}
+/* fix for std post editor used in Smart Grid */
+add_action('cf7sg_enqueue_admin_editor_scripts', 'wpcf7cf_admin_enqueue_form_edit_scripts');
+
+function wpcf7cf_admin_enqueue_form_edit_scripts($hook_suffix){
+	wp_enqueue_script('cf7cf-scripts-admin', wpcf7cf_plugin_url( 'js/scripts_admin.js' ),array('jquery-ui-autocomplete', 'jquery-ui-sortable'), WPCF7CF_VERSION,true);
+	wp_localize_script('cf7cf-scripts-admin', 'wpcf7cf_options_0', wpcf7cf_get_settings());
+	//wp_localize_script('cf7cf-scripts-admin', 'wpcf7cf_newEntryHTML', );
 }
 
 add_filter('wpcf7_editor_panels', 'add_conditional_panel');


### PR DESCRIPTION
The Smart Grid relies on WP core `post.php` to edit wpcf7_contact_form custom posts as forms.

The Conditional plugin added additional checks for CF7 custom admin page editor which results in the scripts not loading for the Smart Grid enabled setup.

The Smart Grid fires a plugin-friendly `cf7sg_enqueue_admin_editor_scripts` action hook for plugins to queue their resources on the form editor page.

The fix delegates the script enqueue process to a new function `wpcf7cf_admin_enqueue_form_edit_scripts()` that is called instead by the conditional cf7 page validation, as well as being hooked to the Smart Grid's action.  A simple solution that allows both scenarios to function.