### PR TITLE
Allow front-end validation

### DIFF
--- a/js/scripts_es6.js
+++ b/js/scripts_es6.js
@@ -51,7 +51,7 @@ let wpcf7cf_change_time_ms = 100; // the timeout after a change in the form is d
 
 if (window.wpcf7 && !wpcf7.setStatus) {
     wpcf7.setStatus = ( form, status ) => {
-        form = form.length ? form[0] : form; // if form is a jQuery object, only grab te html-element
+        form = form instanceof HTMLElement ? form : form[0]; // if form is a jQuery object, only grab te html-element
         const defaultStatuses = new Map( [
             // 0: Status in API response, 1: Status in HTML class
             [ 'init', 'init' ],

--- a/js/scripts_es6.js
+++ b/js/scripts_es6.js
@@ -2,6 +2,7 @@
 
 // disable client side validation introduced in CF7 5.6 for now
 if (typeof wpcf7 !== 'undefined') {
+    wpcf7._cf_validate = wpcf7.validate;
     wpcf7.validate = (a,b) => null;
 }
 

--- a/js/scripts_es6.js
+++ b/js/scripts_es6.js
@@ -32,7 +32,7 @@ if (typeof swv !== 'undefined') {
         }
 
         const unitTag = formData.get("_wpcf7_unit_tag");
-        const $form = jQuery(`input[type="hidden"][value="${unitTag}"]`).closest(form);
+        const $form = jQuery(`input[type="hidden"][value="${unitTag}"]`).closest("form");
         const cfForm = wpcf7cf.getFormObj($form);
 
         // Remove the errors related to the currently hidden fields
@@ -51,7 +51,7 @@ let wpcf7cf_change_time_ms = 100; // the timeout after a change in the form is d
 
 if (window.wpcf7 && !wpcf7.setStatus) {
     wpcf7.setStatus = ( form, status ) => {
-        form = form instanceof HTMLElement ? form : form[0]; // if form is a jQuery object, only grab te html-element
+        form = form instanceof jQuery ? form[0] : form; // if form is a jQuery object, only grab te html-element
         const defaultStatuses = new Map( [
             // 0: Status in API response, 1: Status in HTML class
             [ 'init', 'init' ],


### PR DESCRIPTION
Closes #107, #93

Changes the override point so that the whole `wpcf7.validate` subsystem works as expected whilst removing the "errors" from hidden fields.

That is feasible because wpcf7 currently delegates the whole validation step directly to `swv.validate`, which is much easier to override/decorate.