### PR TITLE
Use recommended version of `$(document).ready`

### DIFF
--- a/js/scripts_admin.js
+++ b/js/scripts_admin.js
@@ -543,7 +543,7 @@ if (typeof(_wpcf7) != 'undefined' || typeof(wpcf7) != 'undefined') {
         wpcf7cf.copyFieldsToText();
     });
     
-    jQuery(document).on('ready', function() {
+    jQuery(document).ready(function() {
     
         wpcf7cf.$if_values = jQuery('.if-value'); // gets updated now and then
     


### PR DESCRIPTION
Hi there! First of all, thank you so much for this very handy plugin! ❤️

Today I noticed that the initialization in `scripts_admin.js` didn't fire on one of my sites:

```js
jQuery(document).on('ready', function() {...})
```

Changing it to the recommended way fixed the plugin for me:

```js
jQuery(document).ready(function() {...})
```

I don't have the issue on all of my sites using your plugin, but I still think it's worth it to use the official jQuery-way for initializing the script.