### PR TITLE
Update plugin header

### DIFF
--- a/contact-form-7-conditional-fields.php
+++ b/contact-form-7-conditional-fields.php
@@ -1,19 +1,26 @@
 <?php
 /**
- * Plugin Name: Conditional Fields for Contact Form 7
- * Plugin URI: https://bdwm.be/
- * Description: Adds support for conditional fields to Contact Form 7.
- * Author: Jules Colle
- * Author URI: https://bdwm.be/
- * License: GPL v2 or later
- * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain: cf7-conditional-fields
- * Version: 2.4.10
- * Requires PHP: 7.0
- * Requires Plugins: contact-form-7
- */
-
-/**
+ * Conditional Fields for Contact Form 7
+ *
+ * @package           CF7_Conditional_Fields
+ * @author            Jules Colle
+ * @copyright         2016 Jules Colle
+ * @license           GPL-2.0-or-later
+ *
+ * @wordpress-plugin
+ * Plugin Name:       Conditional Fields for Contact Form 7
+ * Plugin URI:        https://bdwm.be/
+ * Description:       Adds support for conditional fields to Contact Form 7.
+ * Version:           2.4.10
+ * Requires at least: 5.0
+ * Requires PHP:      7.0
+ * Author:            Jules Colle
+ * Author URI:        https://bdwm.be/
+ * Text Domain:       cf7-conditional-fields
+ * License:           GPL v2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Requires Plugins:  contact-form-7
+ *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
@@ -28,7 +35,6 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-
 
 if ( function_exists( 'wpcf7cf_pro_deactivate_free_version_notice' ) ) {
 	add_action( 'admin_notices', 'wpcf7cf_pro_deactivate_free_version_notice' );

--- a/contact-form-7-conditional-fields.php
+++ b/contact-form-7-conditional-fields.php
@@ -4,12 +4,12 @@
  * Plugin URI: https://bdwm.be/
  * Description: Adds support for conditional fields to Contact Form 7.
  * Author: Jules Colle
- * Version: 2.4.10
- * Requires PHP: 7.0
  * Author URI: https://bdwm.be/
- * Text Domain: cf7-conditional-fields
  * License: GPL v2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain: cf7-conditional-fields
+ * Version: 2.4.10
+ * Requires PHP: 7.0
  * Requires Plugins: contact-form-7
  */
 

--- a/contact-form-7-conditional-fields.php
+++ b/contact-form-7-conditional-fields.php
@@ -1,15 +1,17 @@
 <?php
 /**
-* Plugin Name: Conditional Fields for Contact Form 7
-* Plugin URI: http://bdwm.be/
-* Description: Adds support for conditional fields to Contact Form 7. This plugin depends on Contact Form 7.
-* Author: Jules Colle
-* Version: 2.4.10
-* Author URI: http://bdwm.be/
-* Text Domain: cf7-conditional-fields
-* License: GPL v2 or later
-* License URI: https://www.gnu.org/licenses/gpl-2.0.html
-*/
+ * Plugin Name: Conditional Fields for Contact Form 7
+ * Plugin URI: https://bdwm.be/
+ * Description: Adds support for conditional fields to Contact Form 7.
+ * Author: Jules Colle
+ * Version: 2.4.10
+ * Requires PHP: 7.0
+ * Author URI: https://bdwm.be/
+ * Text Domain: cf7-conditional-fields
+ * License: GPL v2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Requires Plugins: contact-form-7
+ */
 
 /**
  * This program is free software; you can redistribute it and/or modify
@@ -35,9 +37,9 @@ if ( function_exists( 'wpcf7cf_pro_deactivate_free_version_notice' ) ) {
 	function wpcf7cf_pro_deactivate_free_version_notice() {
 		?>
         <div class="notice notice-error is-dismissible">
-			<p><?php 
-			// translators: 1. <a>, 2. </a> 
-			printf( __( '<strong>Conditional Fields for Contact Form 7</strong> needs to %1$sdeactivate the free plugin%1$s', 'cf7-conditional-fields' ), '<a href="' . wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=cf7-conditional-fields%2Fcontact-form-7-conditional-fields.php&amp;plugin_status=all&amp;paged=1&amp;s=', 'deactivate-plugin_cf7-conditional-fields/contact-form-7-conditional-fields.php' ) . '">', '</a>' ); 
+			<p><?php
+			// translators: 1. <a>, 2. </a>
+			printf( __( '<strong>Conditional Fields for Contact Form 7</strong> needs to %1$sdeactivate the free plugin%1$s', 'cf7-conditional-fields' ), '<a href="' . wp_nonce_url( 'plugins.php?action=deactivate&amp;plugin=cf7-conditional-fields%2Fcontact-form-7-conditional-fields.php&amp;plugin_status=all&amp;paged=1&amp;s=', 'deactivate-plugin_cf7-conditional-fields/contact-form-7-conditional-fields.php' ) . '">', '</a>' );
 			?></p>
         </div>
 		<?php


### PR DESCRIPTION
This PR adds the following tags to the plugin header:
- Requires PHP: 7.0
- Requires at least: 5.0
- Requires Plugins: contact-form-7

You use null coalescing operators, which are only available from PHP 7.0 onwards. According to the [WP repo](https://wordpress.org/plugins/cf7-conditional-fields/) WP 5.0 is the minimum required version. The '[Requires Plugins](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/)' tag, introduced in WordPress 6.5, specifies a list of other plugins that the plugin depends on.

This PR also uses https versions for 'Plugin URI' and 'Author URI'.